### PR TITLE
Allow parameterized values to be non-strings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject htmhell "0.1.1"
+(defproject htmhell "0.1.2"
   :description "A really garbage HTML library."
   :url "https://github.com/jimbru/htmhell"
   :license {:name "Eclipse Public License"

--- a/src/htmhell/core.clj
+++ b/src/htmhell/core.clj
@@ -5,7 +5,7 @@
 (defn escape
   "Escape an HTML string."
   [html]
-  (.. html
+  (.. (str html)
       (replace "&" "&amp;")
       (replace "<" "&lt;")
       (replace ">" "&gt;")

--- a/test/htmhell/core_test.clj
+++ b/test/htmhell/core_test.clj
@@ -10,7 +10,9 @@
   (testing "basic functionality"
     (let [s "these{{foo}}are making me {{ bar }}"]
       (is (= (render-string s {:foo " pretzels " :bar "thirsty"})
-             "these pretzels are making me thirsty"))))
+             "these pretzels are making me thirsty"))
+      (is (= (render-string s {:foo " pretzels " :bar 88})
+             "these pretzels are making me 88"))))
   (testing "missing data"
     (let [s "{{foo}} now {{bar}}"]
       (is (= (render-string s {:foo "serenity"})


### PR DESCRIPTION
This allows, for example:

```
(render-string s {:foo " pretzels " :bar 88})

=> "these pretzels are making me 88"))))
```
